### PR TITLE
create data seeds for models: users, tweets, replies, followships, likes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,11 @@
       "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
       "integrity": "sha1-xgkX8m3CNWYVZsaBBhwwPCsohCs="
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "connect-flash": "^0.1.1",

--- a/seeders/20210705161143-users-seed-file.js
+++ b/seeders/20210705161143-users-seed-file.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const bcrypt = require('bcryptjs')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Users', [{
+      id: 1,
+      account: 'user1',
+      email: 'user1@example.com',
+      password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10), null),
+      name: 'user1',
+      avatar: 'https://i.imgur.com/XuNZukl.jpg',
+      cover: '',
+      introduction: 'Hi~ my name is user1',
+      isAdmin: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      id: 2,
+      account: 'user2',
+      email: 'user2@example.com',
+      password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10), null),
+      name: 'user2',
+      avatar: '',
+      cover: '',
+      introduction: 'Hi~ my name is user2',
+      isAdmin: false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      id: 3,
+      account: 'root',
+      email: 'root@example.com',
+      password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10), null),
+      name: 'root',
+      avatar: 'https://i.imgur.com/ldZ2HCe.jpg',
+      cover: '',
+      introduction: 'Hi~ my name is root',
+      isAdmin: true,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      id: 4,
+      account: 'elliotyou',
+      email: 'aaa@aaa.aaa',
+      password: bcrypt.hashSync('aaa', bcrypt.genSaltSync(10), null),
+      name: 'Elliot',
+      avatar: '',
+      cover: '',
+      introduction: 'Hi~ This is Elliot\'s introduction',
+      isAdmin: true,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }], {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Users', null, {})
+  }
+};

--- a/seeders/20210706002936-tweeets-seed-file.js
+++ b/seeders/20210706002936-tweeets-seed-file.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const faker = require('faker')
+
+// const getSmallSize = (text) => {
+//   console.log('into getSmallSize...text', text)
+//   console.log('into getSmallSize...typeof(text)', typeof (text))
+//   return text.slice(0, 130)
+// }
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Tweets',
+      Array.from({ length: 50 }).map((d, i) => ({
+        id: i + 1,
+        UserId: Math.floor(Math.random() * 4) + 1,
+        description: faker.lorem.text().slice(0, 130),
+        createdAt: new Date(),
+        updatedAt: new Date
+      })))
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Tweets', null, {})
+  }
+};

--- a/seeders/20210706011941-replies-seed-file.js
+++ b/seeders/20210706011941-replies-seed-file.js
@@ -1,0 +1,20 @@
+'use strict';
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Replies',
+      Array.from({ length: 200 }).map((d, i) => ({
+        id: i + 1,
+        UserId: Math.floor(Math.random() * 4) + 1,
+        TweetId: Math.floor(Math.random() * 50) + 1,
+        comment: faker.lorem.text().slice(0, 50),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })))
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Replies', null, {})
+  }
+};

--- a/seeders/20210706012643-followship-seed-file.js
+++ b/seeders/20210706012643-followship-seed-file.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const mappingTable = [
+  [1, 2],
+  [1, 3],
+  [1, 4],
+  // [2,1],
+  [2, 3],
+  // [2,4],
+  [3, 1],
+  [3, 2],
+  [3, 4],
+  // [4,1],
+  [4, 2],
+  // [4,3]
+]
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Followships', [{
+      followerId: 1,
+      followingId: 2,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      followerId: 1,
+      followingId: 3,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      followerId: 1,
+      followingId: 4,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      followerId: 2,
+      followingId: 3,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      followerId: 2,
+      followingId: 4,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }, {
+      followerId: 3,
+      followingId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }], {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+  }
+};

--- a/seeders/20210706034103-likes-seed-file.js
+++ b/seeders/20210706034103-likes-seed-file.js
@@ -1,0 +1,52 @@
+'use strict';
+
+function drawFromArray(arr, num) {
+  if (num > arr.length) throw new Error('Error of drawFromArray - Sampling Size too big')
+
+  const drawQuantity = num
+  let samples = []
+  for (let item of arr) {
+    samples.push(item)
+  }
+
+  let count = 1
+  let output = []
+  while (samples.length > 0 && count <= drawQuantity) {
+    const randomIndex = Math.floor(Math.random() * samples.length)
+    const pickedOne = samples.splice(randomIndex, 1)[0]
+    output.push(pickedOne)
+    count++
+  }
+  return output
+}
+
+function likeRelationGenerator() {
+  const userList = [1, 2, 3, 4]  //假所所有user只有這些
+  const tweetList = Array.from(Array(50).keys()).slice(10) //[10,11,...49]
+
+  let output = []
+  for (let user of userList) {   //每個user挑選幾個執行like
+    const samplingNumber = Math.floor(Math.random() * 10) + 5   //挑選數量
+    const pickedOnes = drawFromArray(tweetList, samplingNumber).map(tweet => [user, tweet])    //[[3,5],[3,8],[3,15]...]
+    output.push(...pickedOnes)
+  }
+  return output
+}
+
+const likeRelationList = likeRelationGenerator()
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Likes',
+      likeRelationList.map(paring => ({
+        UserId: paring[0],
+        TweetId: paring[1],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })))
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Likes', null, {})
+  }
+};


### PR DESCRIPTION
把5個table的資料都做了對應的 seed
1. users 
2. tweets
3. replies
4. followships
5. likes

其中，
- users 建 4 個固定的帳號
- tweets 隨機產生 50 筆，發佈人就是 4 個 user 裡隨機挑
- replies 隨機產生 200 筆，發佈人 是 4個 user 裡隨機挑，對應tweet則是 50 筆裡隨機挑
- followship  直接指定一種排列組合，還沒有想到更好的做法，未來有時間可再優化這一段
- likes 這段比較特別，我寫了一個產生器，是讓 4 個 user 各自都有隨機的 like 一些 tweet 

以上，我都有實際 `npx sequelize db:seed:all` 試過，確認可產生資料在我的 MySQL 